### PR TITLE
Fix Backend implementation to work with cursive 0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Inspired by the [comment](https://gitlab.redox-os.org/redox-os/termion/issues/10
 
 ```rust
 let mut app = Cursive::new(|| {
-    let termion_backend = backend::termion::Backend::init();
+    let termion_backend = backend::termion::Backend::init().unwrap();
     let buffered_backend = cursive_buffered_backend::BufferedBackend::new(termion_backend);
     Box::new(buffered_backend)
 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,7 @@ extern crate unicode_width;
 #[macro_use]
 extern crate log;
 
-use crossbeam_channel::{Receiver, Sender};
-use cursive::backend::{Backend, InputRequest};
+use cursive::backend::Backend;
 use cursive::event::Event;
 use cursive::theme;
 use cursive::Vec2;
@@ -193,23 +192,11 @@ impl Backend for BufferedBackend {
         trace!("End finishing BufferedBackend");
     }
 
-    /// Starts a thread to collect input and send it to the given channel.
+    /// Polls the backend for any input.
     ///
-    /// `event_trigger` will receive a value before any event is needed.
-    fn start_input_thread(
-        &mut self,
-        event_sink: Sender<Option<Event>>,
-        input_request: Receiver<InputRequest>,
-    ) {
-        self.backend.start_input_thread(event_sink, input_request);
-    }
-
-    /// Prepares the backend to collect input.
-    ///
-    /// This is only required for non-thread-safe backends like BearLibTerminal
-    /// where we cannot collect input in a separate thread.
-    fn prepare_input(&mut self, input_request: InputRequest) {
-        self.backend.prepare_input(input_request);
+    /// Should return immediately.
+    fn poll_event(&mut self) -> Option<Event> {
+        self.backend.poll_event()
     }
 
     /// Refresh the screen.


### PR DESCRIPTION
Crate fails to build with cursive 0.11+, as the Backend trait definition has been changed.  Fortunately the changes are related to input handling, so are relatively straightforward to fix up.

Errors:
```
error[E0432]: unresolved import `cursive::backend::InputRequest`
  --> src/lib.rs:11:33
   |
11 | use cursive::backend::{Backend, InputRequest};
   |                                 ^^^^^^^^^^^^ no `InputRequest` in `backend`

error[E0407]: method `start_input_thread` is not a member of trait `Backend`
   --> src/lib.rs:199:5
    |
199 | /     fn start_input_thread(
200 | |         &mut self,
201 | |         event_sink: Sender<Option<Event>>,
202 | |         input_request: Receiver<InputRequest>,
203 | |     ) {
204 | |         self.backend.start_input_thread(event_sink, input_request);
205 | |     }
    | |_____^ not a member of trait `Backend`

error[E0407]: method `prepare_input` is not a member of trait `Backend`
   --> src/lib.rs:211:5
    |
211 | /     fn prepare_input(&mut self, input_request: InputRequest) {
212 | |         self.backend.prepare_input(input_request);
213 | |     }
    | |_____^ not a member of trait `Backend`

error[E0046]: not all trait items implemented, missing: `poll_event`
   --> src/lib.rs:184:1
    |
184 | impl Backend for BufferedBackend {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `poll_event` in implementation
    |
    = note: `poll_event` from trait: `fn(&mut Self) -> std::option::Option<cursive::event::Event>`
```

This fix removes the old input functions and replaces them with a passthrough for the new input function.

Many thanks for this crate - I've been happily using it to fix the flickering when using the termion backend.