### PR TITLE
Depend on cursive_core instead of cursive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,8 @@ unicode-width = "0"
 enumset = "1"
 log = "0"
 
-[dependencies.cursive]
-version = ">=0.15"
-default-features = false
+[dependencies.cursive_core]
+version = ">=0.1"
 
 [badges]
 travis-ci = { repository = "agavrilov/cursive_buffered_backend"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate log;
 
+extern crate cursive_core as cursive;
+
 use cursive::backend::Backend;
 use cursive::event::Event;
 use cursive::theme;


### PR DESCRIPTION
This replaces the `cursive` dependency with `cursive_core`.

`cursive_core` is basically `cursive` without the backend implementations.
Hopefully it will have fewer breaking changes thanks to that, which should
make it easier for maintainers of 3rd-party libraries.
