### PR TITLE
Update to cursive-core 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ edition = "2018"
 smallvec = "1"
 unicode-segmentation = "1"
 unicode-width = "0"
-enumset = "1"
+wasmer_enumset = "1"
 log = "0"
 
 [dependencies.cursive_core]
-version = ">=0.1"
+version = ">=0.2"
 
 [badges]
 travis-ci = { repository = "agavrilov/cursive_buffered_backend"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate log;
 
 extern crate cursive_core as cursive;
+extern crate wasmer_enumset as enumset;
 
 use cursive::backend::Backend;
 use cursive::event::Event;
@@ -226,17 +227,6 @@ impl BufferedBackend {
 impl Backend for BufferedBackend {
     fn poll_event(&mut self) -> Option<Event> {
         self.backend.poll_event()
-    }
-
-    // TODO: take `self` by value?
-    // Or implement Drop?
-    /// Prepares to close the backend.
-    ///
-    /// This should clear any state in the terminal.
-    fn finish(&mut self) {
-        trace!("Start finishing BufferedBackend");
-        self.backend.finish();
-        trace!("End finishing BufferedBackend");
     }
 
     /// Refresh the screen.


### PR DESCRIPTION
Backends now rely on `Drop` rather than `finish`, so there's nothing to do in the wrapper.

Note: enumset 1.0 is currently broken (by a non-public breaking change in `syn`), so we're relying on a temporary fork, `wasmer_enumset`, just like `cursive` itself is doing.
Alternatives include waiting for a fix to `enumset` itself or pinning the `syn` version.